### PR TITLE
Update README.md about installation from AUR

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ Download the asset from the [releases page](https://github.com/Edu4rdSHL/fhc/rel
 2. Clone the repo or download the source code, then run `cargo build --release`.
 3. Execute the tool from `./target/release/fhc` or add it to your system PATH to use from anywhere.
 
+## Using the AUR packages. (Arch Linux)
+
+`fhc` can be installed from available [AUR packages](https://aur.archlinux.org/packages/?O=0&SeB=b&K=fhc&outdated=&SB=n&SO=a&PP=50&do_Search=Go) using an [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers). For example,
+
+```
+yay -S fhc
+```
+
 # Usage
 * Show all HTTP urls depite their response codes:
 ```

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ Download the asset from the [releases page](https://github.com/Edu4rdSHL/fhc/rel
 yay -S fhc
 ```
 
+If you prefer, you can clone the [AUR packages](https://aur.archlinux.org/packages/?O=0&SeB=b&K=fhc&outdated=&SB=n&SO=a&PP=50&do_Search=Go) and then compile them with [makepkg](https://wiki.archlinux.org/index.php/Makepkg). For example,
+
+```
+git clone https://aur.archlinux.org/fhc.git && cd fhc && makepkg -si
+```
+
 # Usage
 * Show all HTTP urls depite their response codes:
 ```


### PR DESCRIPTION
Hey,
I'm an [Arch Linux](https://aur.archlinux.org) package [maintainer](https://github.com/orhun/PKGBUILDs). I'm submitting this PR to let you know that I created the following packages for the installation of `fhc` on Arch Linux and other distributions that support installing packages from [AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository):

* [fhc](https://aur.archlinux.org/packages/fhc/) (builds from source)
* [fhc-bin](https://aur.archlinux.org/packages/fhc-bin/) (latest binary)
* [fhc-git](https://aur.archlinux.org/packages/fhc-git/) (VCS/development package)

I also updated README.md about installation from AUR. (8bd485c)

BR,
orhun.